### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "mocha": "5.1.1",
     "nyc": "11.7.1",
     "stringstream": "1.0.0",
-    "lodash": "4.17.21"
+    "lodash": "4.17.21",
+    "qs": "6.13.0"
   },
   "keywords": [
     "jsdoc",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "nyc": "11.7.1",
     "stringstream": "1.0.0",
     "lodash": "4.17.21",
-    "qs": "6.13.0"
+    "qs": "6.13.0",
+    "extend": "3.0.2"
   },
   "keywords": [
     "jsdoc",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fs-extra": "5.0.0",
     "ice-cap": "0.0.4",
     "marked": "0.3.19",
-    "minimist": "1.2.0",
+    "minimist": "1.2.8",
     "taffydb": "2.7.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "stringstream": "1.0.0",
     "lodash": "4.17.21",
     "qs": "6.13.0",
-    "extend": "3.0.2"
+    "extend": "3.0.2",
+    "nth-check": "1.0.2"
   },
   "keywords": [
     "jsdoc",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ice-cap": "0.0.4",
     "marked": "0.3.19",
     "minimist": "1.2.8",
-    "taffydb": "2.7.3"
+    "taffydb": "2.7.3-lineaje-01"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "eslint": "4.19.1",
     "mocha": "5.1.1",
     "nyc": "11.7.1",
-    "stringstream": "1.0.0"
+    "stringstream": "1.0.0",
+    "lodash": "4.17.21"
   },
   "keywords": [
     "jsdoc",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "lodash": "4.17.21",
     "qs": "6.13.0",
     "extend": "3.0.2",
-    "nth-check": "1.0.2"
+    "nth-check": "1.0.2",
+    "css-what": "2.1.3"
   },
   "keywords": [
     "jsdoc",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "esdoc-undocumented-identifier-plugin": "latest",
     "eslint": "4.19.1",
     "mocha": "5.1.1",
-    "nyc": "11.7.1"
+    "nyc": "11.7.1",
+    "stringstream": "1.0.0"
   },
   "keywords": [
     "jsdoc",


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| npm:css-what:2.1.0 | CVE-2022-21222 | High  | The package css-what before 2.1.3 is vulnerable to Regular<br>Expression Denial of Service (ReDoS) due to the use of<br>insecure regular expression in the `re_attr` variable of<br>index.js. The exploitation of this vulnerability could be<br>triggered via the parse function. |
| npm:nth-check:1.0.1 | CVE-2021-3803 | High  | There is a Regular Expression Denial of Service (ReDoS)<br>vulnerability in nth-check that causes a denial of service<br>when parsing crafted invalid CSS nth-checks. The ReDoS<br>vulnerabilities of the regex are mainly due to the<br>sub-pattern `\s*(?:([+-]?)\s*(\d+))?` with quantified<br>overlapping adjacency and can be exploited with the following<br>code. **Proof of Concept** |
| npm:minimist:1.2.0 | CVE-2021-44906 | Critical  | Minimist prior to 1.2.6 and 0.2.4 is vulnerable to Prototype<br>Pollution via file `index.js`, function `setKey()` (lines<br>69-95). |
| npm:stringstream:0.0.5 | CVE-2018-21270 | Medium  | Out-of-bounds Read in stringstream |
| npm:lodash:4.17.10 | CVE-2021-23337 | High  | `lodash` versions prior to 4.17.21 are vulnerable to Command<br>Injection via the template function. |
| npm:lodash:4.17.10 | CVE-2020-28500 | Medium  | All versions of package lodash prior to 4.17.21 are<br>vulnerable to Regular Expression Denial of Service (ReDoS)<br>via the `toNumber`, `trim` and `trimEnd` functions. Steps to<br>reproduce (provided by reporter Liyuan Chen):  |
| npm:lodash:4.17.10 | CVE-2018-16487 | High  | Versions of `lodash` before 4.17.11 are vulnerable to<br>prototype pollution. The vulnerable functions are<br>'defaultsDeep', 'merge', and 'mergeWith' which allow a<br>malicious user to modify the prototype of `Object` via<br>`{constructor: {prototype: {...}}}` causing the addition or<br>modification of an existing property that will exist on all<br>objects. ## Recommendation Update to version 4.17.11 or<br>later. |
| npm:lodash:4.17.10 | CVE-2019-1010266 | Medium  | lodash prior to 4.7.11 is affected by: CWE-400: Uncontrolled<br>Resource Consumption. The impact is: Denial of service. The<br>component is: Date handler. The attack vector is: Attacker<br>provides very long strings, which the library attempts to<br>match using a regular expression. The fixed version is:<br>4.7.11. |
| npm:lodash:4.17.10 | CVE-2019-10744 | Critical  | Versions of `lodash` before 4.17.12 are vulnerable to<br>Prototype Pollution. The function `defaultsDeep` allows a<br>malicious user to modify the prototype of `Object` via<br>`{constructor: {prototype: {...}}}` causing the addition or<br>modification of an existing property that will exist on all<br>objects. ## Recommendation Update to version 4.17.12 or<br>later. |
| npm:lodash:4.17.10 | CVE-2020-8203 | High  | Versions of lodash prior to 4.17.19 are vulnerable to<br>Prototype Pollution. The functions `pick`, `set`, `setWith`,<br>`update`, `updateWith`, and `zipObjectDeep` allow a malicious<br>user to modify the prototype of Object if the property<br>identifiers are user-supplied. Being affected by this issue<br>requires manipulating objects based on user-provided property<br>values or arrays. This vulnerability causes the addition or<br>modification of an existing property that will exist on all<br>objects and may lead to Denial of Service or Code Execution<br>under specific circumstances. |
| npm:qs:6.5.1 | CVE-2022-24999 | High  | qs before 6.10.3 allows attackers to cause a Node process<br>hang because an `__ proto__` key can be used. In many typical<br>web framework use cases, an unauthenticated remote attacker<br>can place the attack payload in the query string of the URL<br>that is used to visit the application, such as<br>`a[__proto__]=b&a[__proto__]&a[length]=100000000`. The fix<br>was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3,<br>6.4.1, 6.3.3, and 6.2.4. |
| npm:extend:3.0.1 | CVE-2018-16492 | Medium  | Versions of `extend` prior to 3.0.2 (for 3.x) and 2.0.2 (for<br>2.x) are vulnerable to Prototype Pollution. The `extend()`<br>function allows attackers to modify the prototype of Object<br>causing the addition or modification of an existing property<br>that will exist on all objects. ## Recommendation If you're<br>using `extend` 3.x upgrade to 3.0.2 or later. If you're using<br>`extend` 2.x upgrade to 2.0.2 or later. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
